### PR TITLE
Zenfone 2 workaround fix for emulation freeze bug

### DIFF
--- a/jni/emulate.c
+++ b/jni/emulate.c
@@ -112,6 +112,8 @@ static word_20 jumpmasks[] = {
   0xffff0000, 0xfff00000, 0xff000000, 0xf0000000
 };
 
+int check_out_register();
+
 int
 #ifdef __FunctionProto__
 decode_group_80(void)
@@ -694,7 +696,7 @@ decode_group_1()
   }
 }
 
-inline int
+int
 #ifdef __FunctionProto__
 decode_8_thru_f(int op1)
 #else

--- a/jni/x48.c
+++ b/jni/x48.c
@@ -629,7 +629,13 @@ GetEvent()
 	
 	int code = (*android_env)->CallIntMethod(android_env, android_callback, waitEvent);
 
-//LOGI("code: %d", code);
+    //LOGI("code: %d", code);
+    //FIX for Zenfone 2
+    struct timespec req, rem;
+    req.tv_sec = 0;
+    req.tv_nsec = 100L;
+    nanosleep(&req , &rem);
+
 	if (code < 0)
 	{
 		code = -code;


### PR DESCRIPTION
This is a workaround fix for the app freeze on Zenfone 2.
The app freezes because the events are not being consumed. Uncomment LOGI("code: %d", code); on x48.c(line 632) fix the freeze (I found this while trying to debug this freeze). To avoid unnecessary LOG i've added an nanosleep().
I have not found what cause the consumer of the events to stop working. 

The changes in emulate.c are because the Android SDK i used(25.0) was not compiling the lib.