### PR TITLE
Show the newly-loaded object on the stack.

### DIFF
--- a/app/src/main/java/org/ab/x48/X48.java
+++ b/app/src/main/java/org/ab/x48/X48.java
@@ -407,6 +407,7 @@ public class X48 extends Activity {
    						boolean msgbox = mPrefs.getBoolean("no_loadprog_msgbox", false);
    						if (!msgbox)
    							showDialog(DIALOG_PROG_OK);
+   						pressOnKey();
    					} else {
    						showDialog(DIALOG_PROG_KO);
    					}
@@ -423,7 +424,16 @@ public class X48 extends Activity {
    		}
    	}
    }
-   
+
+   private void pressOnKey() {
+       // When a file is loaded, the loaded object is not shown on
+       // the stack. Pressing the 'ON' key will refresh the screen
+       // and the just-loaded object will be shown on the stack.
+       int ON_KEY_CODE = 44;
+       mainView.key(ON_KEY_CODE, true);
+       mainView.key(ON_KEY_CODE, false);
+   }
+
    private boolean saveonExit;
    private boolean hp48s;
    private boolean bitmapSkin = false;


### PR DESCRIPTION
When a program is loaded from the file system, the loaded object is pushed onto the stack, but the object is not visible on the screen of the calculator. This change makes the object visible.

